### PR TITLE
Fix daughter references, and better packing of puppi weights.

### DIFF
--- a/DataFormats/PatCandidates/interface/liblogintpack.h
+++ b/DataFormats/PatCandidates/interface/liblogintpack.h
@@ -29,6 +29,21 @@ namespace logintpack
 		return r;
 	}
 
+        /// pack a value x distributed in [-1,1], with guarantee that -1 and 1 are preserved exactly in packing and unpacking.
+        /// tries to keep the best precision for x close to the endpoints, sacrifying that in the middle
+	int8_t pack8logClosed(double x,double lmin, double lmax, uint8_t base=128)
+	{
+	        if(base>128) base=128;
+		float l =log(fabs(x));
+		float centered = (l-lmin)/(lmax-lmin)*(base-1);
+		int8_t  r=round(centered);
+		if(centered >= base-1) r=base-1;
+		if(centered < 0) r=0;
+		if(x<0) r=-r;
+		return r;
+	}
+
+
 	double unpack8log(int8_t i,double lmin, double lmax, uint8_t base=128)
 	{
 	        if(base>128) base=128;
@@ -37,5 +52,17 @@ namespace logintpack
 		float val=exp(l);
 		if(i<0) return -val; else return val;
 	}
+
+        /// reverse of pack8logClosed
+	double unpack8logClosed(int8_t i,double lmin, double lmax, uint8_t base=128)
+	{
+	        if(base>128) base=128;
+	        float basef=base-1;
+		float l=lmin+abs(i)/basef*(lmax-lmin);
+                if (abs(i) == base-1) l = lmax;
+		float val=exp(l);
+		if(i<0) return -val; else return val;
+	}
+
 }
 #endif

--- a/DataFormats/PatCandidates/src/PackedCandidate.cc
+++ b/DataFormats/PatCandidates/src/PackedCandidate.cc
@@ -269,7 +269,7 @@ bool pat::PackedCandidate::longLived() const {return false;}
 bool pat::PackedCandidate::massConstraint() const {return false;}
 
 // puppiweight
-void pat::PackedCandidate::setPuppiWeight(float p) { packedPuppiweight_ = pack8log((p-0.5)*2,-2,0,64);}
+void pat::PackedCandidate::setPuppiWeight(float p) { packedPuppiweight_ = pack8logClosed((p-0.5)*2,-2,0,64);}
 
-float pat::PackedCandidate::puppiWeight() const { return unpack8log(packedPuppiweight_,-2,0,64)/2. + 0.5;}
+float pat::PackedCandidate::puppiWeight() const { return unpack8logClosed(packedPuppiweight_,-2,0,64)/2. + 0.5;}
 

--- a/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
@@ -225,14 +225,17 @@ void pat::PATPackedCandidateProducer::produce(edm::Event& iEvent, const edm::Eve
 
     std::auto_ptr< std::vector<pat::PackedCandidate> > outPtrPSorted( new std::vector<pat::PackedCandidate> );
     std::vector<size_t> order=sort_indexes(*outPtrP);
+    std::vector<size_t> reverseOrder(order.size());
     for(size_t i=0,nc=cands->size();i<nc;i++) {
         outPtrPSorted->push_back((*outPtrP)[order[i]]);
+        reverseOrder[order[i]] = i;
         mappingReverse[order[i]]=i;
+        mappingPuppi[order[i]]=i;
     }
 
     // Fix track association for sorted candidates
     for(size_t i=0,ntk=mappingTk.size();i<ntk;i++){
-        mappingTk[i]=order[mappingTk[i]];
+        mappingTk[i]=reverseOrder[mappingTk[i]]; 
     }
 
     


### PR DESCRIPTION
- now weights of zero and one are preserved exactly in the packing
- daughters are mapped correctly (was not so after #8133)
- also, fix the mapping between track refs and packed pfcandidates that was broken in #8133
